### PR TITLE
Fix ESM path resolution

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,9 @@ import express, { Request, Response } from 'express';
 import cors from 'cors';
 import { promises as fs } from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const app = express();
 app.use(cors());


### PR DESCRIPTION
## Summary
- resolve `__dirname` when running the backend in ESM mode

## Testing
- `npm run build` in `backend`
- `node dist/index.js`

------
https://chatgpt.com/codex/tasks/task_e_684abf7c4fe8832ab797879b0c2e53da